### PR TITLE
bug fix tail_target_checker()

### DIFF
--- a/ndkgc/models/fcn_model_v2.py
+++ b/ndkgc/models/fcn_model_v2.py
@@ -846,7 +846,7 @@ def main(_):
                                                    os.path.join(dataset_dir, 'avoid_entities.txt'))
 
             eval_targets = list(eval_targets_set)
-
+            dic = eval_targets
             if len(eval_targets_set) == 0:
                 tf.logging.warning("eval_targets_set is empty!")
 


### PR DESCRIPTION
In the main func, the arguments to tail_target_checker() contains **dic**. Inside this method, a new list of target entities are defined and top-10 ids are computed with respect to new list. But while returning results, indices are referred with respect to input **dic**. Thus the results observed while using this method seem to be wrong.